### PR TITLE
use json.net to serialize since bad mono serialization issues.

### DIFF
--- a/Trakt/Extensions.cs
+++ b/Trakt/Extensions.cs
@@ -1,14 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.Serialization.Json;
-using System.Text;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Model.Entities;
-using MediaBrowser.Model.Logging;
-using Trakt.Api.DataContracts;
+using Newtonsoft.Json;
 using Trakt.Api.DataContracts.Users.Collection;
 
 namespace Trakt
@@ -143,12 +139,8 @@ namespace Trakt
         public static string ToJSON(this object obj)
         {
             if (obj == null) return string.Empty;
-            using (var ms = new MemoryStream())
-            {
-                var ser = new DataContractJsonSerializer(obj.GetType());
-                ser.WriteObject(ms, obj);
-                return Encoding.UTF8.GetString(ms.ToArray());
-            }
+            return JsonConvert.SerializeObject(obj,
+                    new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
         }
 
         public static string ToISO8601(this DateTime dt, double hourShift = 0)

--- a/Trakt/FodyWeavers.xml
+++ b/Trakt/FodyWeavers.xml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Weavers>
+	<Costura/>
+  
+</Weavers>

--- a/Trakt/Trakt.csproj
+++ b/Trakt/Trakt.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -50,6 +52,10 @@
     <Reference Include="MediaBrowser.Model, Version=3.0.5754.42116, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\MediaBrowser.Common.3.0.637\lib\net45\MediaBrowser.Model.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Patterns.Logging">
       <HintPath>..\packages\Patterns.Logging.1.0.0.2\lib\portable-net45+sl4+wp71+win8+wpa81\Patterns.Logging.dll</HintPath>
@@ -134,7 +140,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Content Include="FodyWeavers.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetPath)" "$(SolutionDir)\..\MediaBrowser.Dev\ProgramData-Server\Plugins\" /y</PostBuildEvent>
@@ -145,7 +153,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+    <Error Condition="!Exists('..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets'))" />
   </Target>
+  <Import Project="..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Trakt/packages.config
+++ b/Trakt/packages.config
@@ -1,9 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonIO" version="1.0.0.4" targetFramework="net45" />
+  <package id="Costura.Fody" version="1.3.5.0" targetFramework="net45" developmentDependency="true" />
+  <package id="Fody" version="1.29.3" targetFramework="net45" developmentDependency="true" />
   <package id="Interfaces.IO" version="1.0.0.5" targetFramework="net45" />
   <package id="MediaBrowser.Common" version="3.0.637" targetFramework="net45" />
   <package id="MediaBrowser.Server.Core" version="3.0.637" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="Patterns.Logging" version="1.0.0.2" targetFramework="net45" />
   <package id="ServiceStack.Interfaces" version="4.0.35" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
For some reason the implementation on Mono for the DataContractJsonSerializer is ignoring the EmitDefaultValue Attributes. This generates an invalid JSON that is rejected by the Trakt API.

Example:
{"app_date":"2015-10-31","app_version":"3.0.5768.7","episode":{"ids":{"imdb":null,"slug":null,"tmdb":null,"trakt":null,"tvdb":5337299,"tvrage":null},"number":null,"season":null,"title":null},"progress":100,"show":null}

The correct Json would be:
{"app_date":"2015-10-31","app_version":"3.0.5768.7","episode":{"ids":{"tvdb":5337299}},"progress":100}

Also, Included Costura.Fody to embed the External Library dependency into one single DLL.

After the build the only file needed is the single Trakt.dll one.

The issue was discovered while using the Emby build for qnap.