### PR TITLE
Remove direct-stream only requirement

### DIFF
--- a/RokuMetadata/Drawing/VideoProcessor.cs
+++ b/RokuMetadata/Drawing/VideoProcessor.cs
@@ -62,11 +62,6 @@ namespace RokuMetadata.Drawing
                     MediaSourceId = mediaSource.Id
                 });
 
-                if (!streamInfo.IsDirectStream)
-                {
-                    continue;
-                }
-
                 if (Plugin.Instance.Configuration.EnableHdThumbnails)
                 {
                     await Run(item, modifier, mediaSource, 320, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
The roku can display BIF with transcoded streams in an HLS container. This removes the restriction to only create BIF on media which has the directstream bit set.